### PR TITLE
add comments to safe types

### DIFF
--- a/src/Type/SafeDateTimeType.php
+++ b/src/Type/SafeDateTimeType.php
@@ -40,4 +40,9 @@ class SafeDateTimeType extends DateTimeType
 
         return $dateTime;
     }
+
+    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
+    {
+        return true;
+    }
 }

--- a/src/Type/SafeDateTimeTzType.php
+++ b/src/Type/SafeDateTimeTzType.php
@@ -40,4 +40,9 @@ class SafeDateTimeTzType extends DateTimeTzType
 
         return $dateTime;
     }
+
+    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
+    {
+        return true;
+    }
 }

--- a/src/Type/SafeDateType.php
+++ b/src/Type/SafeDateType.php
@@ -40,4 +40,9 @@ class SafeDateType extends DateType
 
         return $dateTime;
     }
+
+    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
+    {
+        return true;
+    }
 }

--- a/src/Type/SafeTimeType.php
+++ b/src/Type/SafeTimeType.php
@@ -40,4 +40,9 @@ class SafeTimeType extends TimeType
 
         return $dateTime;
     }
+
+    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
+    {
+        return true;
+    }
 }


### PR DESCRIPTION
Hi.

First of all for this nice little extension.

There is unfortunately a little problem: Since they have the same database type as their parent-types, doctrine migrations cannot tell the difference and therefore a new migration is always created. Doctrine uses daatabase-comments to fix this. This PR adds the required functions, so that those comments are created.