### PR TITLE
Use doctrine/dbal and allow more versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
     "license": "MIT",
     "type": "library",
     "require": {
-        "php": "^7.1|^8.0",
-        "doctrine/orm": "^2.7",
+        "php": ">=7.4",
+        "doctrine/dbal": "^3.0|^4.0",
         "thecodingmachine/safe": "^1.1|^2.0"
     },
     "require-dev": {

--- a/src/Type/SafeDateImmutableType.php
+++ b/src/Type/SafeDateImmutableType.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace DobryProgramator\DoctrineSafeTypes\Type;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\DateImmutableType;
+use Doctrine\DBAL\Types\Exception\InvalidFormat;
 use Safe\DateTimeImmutable as SafeDateTimeImmutable;
 use Safe\Exceptions\DatetimeException;
 
@@ -20,7 +20,7 @@ class SafeDateImmutableType extends DateImmutableType
     /**
      * @param mixed $value
      *
-     * @throws ConversionException
+     * @throws InvalidFormat
      */
     public function convertToPHPValue($value, AbstractPlatform $platform): ?SafeDateTimeImmutable
     {
@@ -31,7 +31,7 @@ class SafeDateImmutableType extends DateImmutableType
         try {
             $dateTime = SafeDateTimeImmutable::createFromFormat('!' . $platform->getDateFormatString(), $value);
         } catch (DatetimeException $e) {
-            throw ConversionException::conversionFailedFormat(
+            throw new InvalidFormat(
                 $value,
                 $this->getName(),
                 $platform->getDateFormatString()

--- a/src/Type/SafeDateTimeImmutableType.php
+++ b/src/Type/SafeDateTimeImmutableType.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace DobryProgramator\DoctrineSafeTypes\Type;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\DateTimeImmutableType;
+use Doctrine\DBAL\Types\Exception\InvalidFormat;
 use Safe\DateTimeImmutable as SafeDateTimeImmutable;
 use Safe\Exceptions\DatetimeException;
 
@@ -20,7 +20,7 @@ class SafeDateTimeImmutableType extends DateTimeImmutableType
     /**
      * @param mixed $value
      *
-     * @throws ConversionException
+     * @throws InvalidFormat
      */
     public function convertToPHPValue($value, AbstractPlatform $platform): ?SafeDateTimeImmutable
     {
@@ -31,7 +31,7 @@ class SafeDateTimeImmutableType extends DateTimeImmutableType
         try {
             $dateTime = SafeDateTimeImmutable::createFromFormat($platform->getDateTimeFormatString(), $value);
         } catch (DatetimeException $e) {
-            throw ConversionException::conversionFailedFormat(
+            throw new InvalidFormat(
                 $value,
                 $this->getName(),
                 $platform->getDateTimeFormatString()

--- a/src/Type/SafeDateTimeType.php
+++ b/src/Type/SafeDateTimeType.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace DobryProgramator\DoctrineSafeTypes\Type;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\DateTimeType;
+use Doctrine\DBAL\Types\Exception\InvalidFormat;
 use Safe\DateTime as SafeDateTime;
 use Safe\Exceptions\DatetimeException;
 
@@ -20,7 +20,7 @@ class SafeDateTimeType extends DateTimeType
     /**
      * @param mixed $value
      *
-     * @throws ConversionException
+     * @throws InvalidFormat
      */
     public function convertToPHPValue($value, AbstractPlatform $platform): ?SafeDateTime
     {
@@ -31,7 +31,7 @@ class SafeDateTimeType extends DateTimeType
         try {
             $dateTime = SafeDateTime::createFromFormat($platform->getDateTimeFormatString(), $value);
         } catch (DatetimeException $e) {
-            throw ConversionException::conversionFailedFormat(
+            throw new InvalidFormat(
                 $value,
                 $this->getName(),
                 $platform->getDateTimeFormatString()

--- a/src/Type/SafeDateTimeTzImmutableType.php
+++ b/src/Type/SafeDateTimeTzImmutableType.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace DobryProgramator\DoctrineSafeTypes\Type;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\DateTimeTzImmutableType;
+use Doctrine\DBAL\Types\Exception\InvalidFormat;
 use Safe\DateTimeImmutable as SafeDateTimeImmutable;
 use Safe\Exceptions\DatetimeException;
 
@@ -20,7 +20,7 @@ class SafeDateTimeTzImmutableType extends DateTimeTzImmutableType
     /**
      * @param mixed $value
      *
-     * @throws ConversionException
+     * @throws InvalidFormat
      */
     public function convertToPHPValue($value, AbstractPlatform $platform): ?SafeDateTimeImmutable
     {
@@ -31,7 +31,7 @@ class SafeDateTimeTzImmutableType extends DateTimeTzImmutableType
         try {
             $dateTime = SafeDateTimeImmutable::createFromFormat($platform->getDateTimeTzFormatString(), $value);
         } catch (DatetimeException $e) {
-            throw ConversionException::conversionFailedFormat(
+            throw new InvalidFormat(
                 $value,
                 $this->getName(),
                 $platform->getDateTimeTzFormatString()

--- a/src/Type/SafeDateTimeTzType.php
+++ b/src/Type/SafeDateTimeTzType.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace DobryProgramator\DoctrineSafeTypes\Type;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\DateTimeTzType;
+use Doctrine\DBAL\Types\Exception\InvalidFormat;
 use Safe\DateTime as SafeDateTime;
 use Safe\Exceptions\DatetimeException;
 
@@ -20,7 +20,7 @@ class SafeDateTimeTzType extends DateTimeTzType
     /**
      * @param mixed $value
      *
-     * @throws ConversionException
+     * @throws InvalidFormat
      */
     public function convertToPHPValue($value, AbstractPlatform $platform): ?SafeDateTime
     {
@@ -31,7 +31,7 @@ class SafeDateTimeTzType extends DateTimeTzType
         try {
             $dateTime = SafeDateTime::createFromFormat($platform->getDateTimeTzFormatString(), $value);
         } catch (DatetimeException $e) {
-            throw ConversionException::conversionFailedFormat(
+            throw new InvalidFormat(
                 $value,
                 $this->getName(),
                 $platform->getDateTimeTzFormatString()

--- a/src/Type/SafeDateType.php
+++ b/src/Type/SafeDateType.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace DobryProgramator\DoctrineSafeTypes\Type;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\DateType;
+use Doctrine\DBAL\Types\Exception\InvalidFormat;
 use Safe\DateTime as SafeDateTime;
 use Safe\Exceptions\DatetimeException;
 
@@ -20,7 +20,7 @@ class SafeDateType extends DateType
     /**
      * @param mixed $value
      *
-     * @throws ConversionException
+     * @throws InvalidFormat
      */
     public function convertToPHPValue($value, AbstractPlatform $platform): ?SafeDateTime
     {
@@ -31,7 +31,7 @@ class SafeDateType extends DateType
         try {
             $dateTime = SafeDateTime::createFromFormat('!' . $platform->getDateFormatString(), $value);
         } catch (DatetimeException $e) {
-            throw ConversionException::conversionFailedFormat(
+            throw new InvalidFormat(
                 $value,
                 $this->getName(),
                 $platform->getDateFormatString()

--- a/src/Type/SafeTimeImmutableType.php
+++ b/src/Type/SafeTimeImmutableType.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace DobryProgramator\DoctrineSafeTypes\Type;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Exception\InvalidFormat;
 use Doctrine\DBAL\Types\TimeImmutableType;
 use Safe\DateTimeImmutable as SafeDateTimeImmutable;
 use Safe\Exceptions\DatetimeException;
@@ -20,7 +20,7 @@ class SafeTimeImmutableType extends TimeImmutableType
     /**
      * @param mixed $value
      *
-     * @throws ConversionException
+     * @throws InvalidFormat
      */
     public function convertToPHPValue($value, AbstractPlatform $platform): ?SafeDateTimeImmutable
     {
@@ -31,7 +31,7 @@ class SafeTimeImmutableType extends TimeImmutableType
         try {
             $dateTime = SafeDateTimeImmutable::createFromFormat('!' . $platform->getTimeFormatString(), $value);
         } catch (DatetimeException $e) {
-            throw ConversionException::conversionFailedFormat(
+            throw new InvalidFormat(
                 $value,
                 $this->getName(),
                 $platform->getTimeFormatString()

--- a/src/Type/SafeTimeType.php
+++ b/src/Type/SafeTimeType.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace DobryProgramator\DoctrineSafeTypes\Type;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Exception\InvalidFormat;
 use Doctrine\DBAL\Types\TimeType;
 use Safe\DateTime as SafeDateTime;
 use Safe\Exceptions\DatetimeException;
@@ -20,7 +20,7 @@ class SafeTimeType extends TimeType
     /**
      * @param mixed $value
      *
-     * @throws ConversionException
+     * @throws InvalidFormat
      */
     public function convertToPHPValue($value, AbstractPlatform $platform): ?SafeDateTime
     {
@@ -31,7 +31,7 @@ class SafeTimeType extends TimeType
         try {
             $dateTime = SafeDateTime::createFromFormat('!' . $platform->getTimeFormatString(), $value);
         } catch (DatetimeException $e) {
-            throw ConversionException::conversionFailedFormat(
+            throw new InvalidFormat(
                 $value,
                 $this->getName(),
                 $platform->getTimeFormatString()


### PR DESCRIPTION
I don't think doctrine/orm is necessary as a dependency as the only classes being used are from the doctrine/dbal package.

PHP-Versionupdate is necessary for type declarations.